### PR TITLE
Update status.ObservedGeneration for failure phase

### DIFF
--- a/pkg/controller/cluster.go
+++ b/pkg/controller/cluster.go
@@ -376,6 +376,6 @@ func (c *Controller) updateCRStatus(cl *Cluster) error {
 		in.ObservedGeneration = cl.cluster.Generation
 		in.ObservedGenerationHash = meta_util.GenerationHash(cl.cluster)
 		return in
-	})
+	}, api.EnableStatusSubresource)
 	return err
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"github.com/appscode/go/log"
 	apiext_util "github.com/appscode/kutil/apiextensions/v1beta1"
+	meta_util "github.com/appscode/kutil/meta"
 	"github.com/appscode/kutil/tools/queue"
 	pcm "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	api "github.com/kubedb/apimachinery/apis/kubedb/v1alpha1"
@@ -166,8 +167,10 @@ func (c *Controller) pushFailureEvent(etcd *api.Etcd, reason string) {
 	db, err := kutildb.UpdateEtcdStatus(c.ExtClient, etcd, func(in *api.EtcdStatus) *api.EtcdStatus {
 		in.Phase = api.DatabasePhaseFailed
 		in.Reason = reason
+		in.ObservedGeneration = etcd.Generation
+		in.ObservedGenerationHash = meta_util.GenerationHash(etcd)
 		return in
-	})
+	}, api.EnableStatusSubresource)
 	if err != nil {
 		if ref, rerr := reference.GetReference(clientsetscheme.Scheme, etcd); rerr == nil {
 			c.recorder.Eventf(

--- a/pkg/controller/etcd.go
+++ b/pkg/controller/etcd.go
@@ -134,7 +134,7 @@ func (c *Controller) handleEtcdEvent(event *Event) error {
 		in.ObservedGeneration = etcd.Generation
 		in.ObservedGenerationHash = meta_util.GenerationHash(etcd)
 		return in
-	})
+	}, api.EnableStatusSubresource)
 
 	if err != nil {
 		if ref, rerr := reference.GetReference(clientsetscheme.Scheme, etcd); rerr == nil {
@@ -209,7 +209,7 @@ func (c *Controller) initialize(etcd *api.Etcd) error {
 	db, err := util.UpdateEtcdStatus(c.ExtClient, etcd, func(in *api.EtcdStatus) *api.EtcdStatus {
 		in.Phase = api.DatabasePhaseInitializing
 		return in
-	})
+	}, api.EnableStatusSubresource)
 	if err != nil {
 		if ref, rerr := reference.GetReference(clientsetscheme.Scheme, etcd); rerr == nil {
 			c.recorder.Eventf(

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -96,7 +96,7 @@ func (c *Controller) checkService(etcd *api.Etcd, serviceName string) error {
 		return err
 	}
 
-	if service.Labels[api.LabelDatabaseKind] != api.ResourceKindMySQL ||
+	if service.Labels[api.LabelDatabaseKind] != api.ResourceKindEtcd ||
 		service.Labels[api.LabelDatabaseName] != etcd.Name {
 		return fmt.Errorf(`intended service "%v" already exists`, serviceName)
 	}

--- a/pkg/controller/snapshot.go
+++ b/pkg/controller/snapshot.go
@@ -32,7 +32,7 @@ func (c *Controller) SetDatabaseStatus(meta metav1.ObjectMeta, phase api.Databas
 		in.Phase = phase
 		in.Reason = reason
 		return in
-	})
+	}, api.EnableStatusSubresource)
 	return err
 }
 

--- a/test/e2e/framework/snapshot.go
+++ b/test/e2e/framework/snapshot.go
@@ -21,7 +21,7 @@ func (f *Invocation) Snapshot() *api.Snapshot {
 			Name:      rand.WithUniqSuffix("snapshot"),
 			Namespace: f.namespace,
 			Labels: map[string]string{
-				"app":                 f.app,
+				"app": f.app,
 				api.LabelDatabaseKind: api.ResourceKindEtcd,
 			},
 		},


### PR DESCRIPTION
- EnableStatusSubresource for Status update
- Update status.ObservedGeneration for failure phase
-  Fixed label matching of existing service